### PR TITLE
Performed GPU detection using GPUtil library instead of torch

### DIFF
--- a/GlossAi/requirements.txt
+++ b/GlossAi/requirements.txt
@@ -1,3 +1,4 @@
 faster-whisper>=1.0.0
 regex>=2024.5.15
 ffmpeg-python>=0.2.0
+gputil>=1.4.0


### PR DESCRIPTION
- Removed torch library
- Reason: Less bloat since torch library is significantly larger than GPUtil library